### PR TITLE
Fix compatibility with latest MOTION

### DIFF
--- a/compiler/compiler/motion_backend/collect_stats.cpp
+++ b/compiler/compiler/motion_backend/collect_stats.cpp
@@ -14,169 +14,30 @@
 
 using namespace encrypto::motion;
 
-bool is_local(const GatePointer &gate)
-{
-    return dynamic_cast<proto::boolean_gmw::XorGate *>(&*gate) ||
-           dynamic_cast<proto::bmr::XorGate *>(&*gate) ||
-           dynamic_cast<proto::boolean_gmw::InvGate *>(&*gate) ||
-           dynamic_cast<proto::bmr::InvGate *>(&*gate) || dynamic_cast<SimdifyGate *>(&*gate) ||
-           dynamic_cast<UnsimdifyGate *>(&*gate);
-}
-
-std::vector<std::int64_t> collect_children(const BackendPointer backend, const std::int64_t gate_id,
-                                           std::unordered_set<std::int64_t> &seen_gates)
-{
-    std::vector<std::int64_t> children;
-
-    const auto gate = backend->GetGate(gate_id);
-
-    for (const auto &output_wire : gate->GetOutputWires()) {
-        for (const auto &child_gate_id : output_wire->GetWaitingGatesIds()) {
-            if (seen_gates.find(child_gate_id) != seen_gates.end()) {
-                continue;
-            }
-
-            const auto child_gate = backend->GetGate(child_gate_id);
-            if (is_local(child_gate)) {
-                auto child_children = collect_children(backend, child_gate_id, seen_gates);
-
-                children.insert(children.end(), child_children.begin(), child_children.end());
-            } else {
-                children.push_back(child_gate_id);
-            }
-
-            seen_gates.insert(child_gate_id);
-        }
-    }
-
-    return children;
-}
-
 CircuitStats collect_stats(const BackendPointer backend)
 {
     CircuitStats stats;
-    std::unordered_set<std::int64_t> visited_gates;
 
-    std::ofstream dot("circuit.dot");
-    dot << "digraph circuit {" << std::endl;
-
-    // Perform a breadth-first traversal of the circuit, collecting data as we go
-    std::queue<std::pair<const WirePointer, const std::int64_t>> queue;
-    for (const auto &gate : backend->GetRegister()->GetGates()) {
+    for (const GatePointer gate : backend->GetRegister()->GetGates()) {
+        stats.num_gates++;
         if (dynamic_cast<InputGate *>(&*gate)) {
-            queue.push(std::make_pair(nullptr, gate->GetId()));
+            stats.num_inputs++;
         }
-    }
-
-    while (!queue.empty()) {
-        const auto [wire, gate_id] = queue.front();
-        queue.pop();
-
-        // If we've already visited this gate, skip it
-        if (visited_gates.find(gate_id) != visited_gates.end()) {
-            continue;
-        }
-        visited_gates.insert(gate_id);
-
-        const auto gate = backend->GetGate(gate_id);
-
-        if (dynamic_cast<InputGate *>(&*gate)) {
-            dot << gate_id << " [label=\"Input\"";
-        } else if (dynamic_cast<OutputGate *>(&*gate)) {
-            dot << gate_id << " [label=\"Output\"";
-        } else if (dynamic_cast<proto::boolean_gmw::XorGate *>(&*gate) ||
-                   dynamic_cast<proto::bmr::XorGate *>(&*gate)) {
-            dot << gate_id << " [label=\"Xor\"";
-        } else if (dynamic_cast<proto::boolean_gmw::InvGate *>(&*gate) ||
-                   dynamic_cast<proto::bmr::InvGate *>(&*gate)) {
-            dot << gate_id << " [label=\"Not\"";
-        } else if (dynamic_cast<proto::boolean_gmw::AndGate *>(&*gate) ||
-                   dynamic_cast<proto::bmr::AndGate *>(&*gate)) {
-            dot << gate_id << " [label=\"And\"";
-        } else if (dynamic_cast<proto::boolean_gmw::MuxGate *>(&*gate)) {
-            dot << gate_id << " [label=\"Mux\"";
-        } else if (dynamic_cast<SimdifyGate *>(&*gate)) {
-            dot << gate_id << " [label=\"Simdify\"";
-        } else if (dynamic_cast<UnsimdifyGate *>(&*gate)) {
-            dot << gate_id << " [label=\"Unsimdify\"";
-        } else {
-            throw std::runtime_error("Unknown gate type");
-        }
-
-        if (is_local(gate)) {
-            dot << ", fillcolor=\"red\", style=\"filled\"";
-        }
-        dot << "];" << std::endl;
-
-        // Count the gate
-        ++stats.num_gates;
-
-        // If this is an input gate, increment the number of inputs
-        if (dynamic_cast<InputGate *>(&*gate)) {
-            ++stats.num_inputs;
-        }
-
-        // If this is an output gate, increment the number of outputs
         if (dynamic_cast<OutputGate *>(&*gate)) {
-            ++stats.num_outputs;
+            stats.num_outputs++;
         }
-
-        // If this is not an input gate (i.e. there is a wire which leads into this gate),
-        // determine if that wire is SIMD
-        if (wire != nullptr) {
-            if (wire->GetNumberOfSimdValues() > 1) {
-                ++stats.num_simd_gates;
-            } else {
-                ++stats.num_nonsimd_gates;
+        bool is_simd = true;
+        for (const WirePointer wire : gate->GetOutputWires()) {
+            if (wire->GetNumberOfSimdValues() <= 1) {
+                is_simd = false;
+                break;
             }
         }
-
-        std::unordered_set<std::int64_t> visited_children;
-
-        // Add all children to the queue
-        for (const auto &output_wire : gate->GetOutputWires()) {
-            for (const auto &child_gate_id : output_wire->GetWaitingGatesIds()) {
-                if (visited_children.find(child_gate_id) == visited_children.end()) {
-                    dot << gate_id << " -> " << child_gate_id << "[label=\""
-                        << output_wire->GetNumberOfSimdValues() << "\"];" << std::endl;
-                    queue.push(std::make_pair(output_wire, child_gate_id));
-                    visited_children.insert(child_gate_id);
-                }
-            }
+        if (is_simd) {
+            stats.num_simd_gates++;
+        } else {
+            stats.num_nonsimd_gates++;
         }
-    }
-    dot << "}" << std::endl;
-
-    std::queue<std::int64_t> write_queue;
-    std::queue<std::int64_t> read_queue;
-    for (const auto &gate : backend->GetRegister()->GetGates()) {
-        if (dynamic_cast<InputGate *>(&*gate)) {
-            read_queue.push(gate->GetId());
-        }
-    }
-
-    stats.depth = 0;
-
-    while (!read_queue.empty()) {
-        ++stats.depth;
-
-        std::unordered_set<std::int64_t> seen_gates;
-        while (!read_queue.empty()) {
-            const auto gate_id = read_queue.front();
-            read_queue.pop();
-            const auto gate = backend->GetGate(gate_id);
-
-            if (dynamic_cast<OutputGate *>(&*gate)) {
-                continue;
-            }
-
-            auto children = collect_children(backend, gate_id, seen_gates);
-
-            for (const auto &child_gate_id : children) {
-                write_queue.push(child_gate_id);
-            }
-        }
-        std::swap(read_queue, write_queue);
     }
 
     return stats;
@@ -189,6 +50,5 @@ std::ostream &operator<<(std::ostream &ostr, const CircuitStats &stats)
     ostr << "num_outputs: " << stats.num_outputs << std::endl;
     ostr << "num_simd_gates: " << stats.num_simd_gates << std::endl;
     ostr << "num_nonsimd_gates: " << stats.num_nonsimd_gates << std::endl;
-    ostr << "depth: " << stats.depth << std::endl;
     return ostr;
 }

--- a/compiler/compiler/motion_backend/collect_stats.h
+++ b/compiler/compiler/motion_backend/collect_stats.h
@@ -11,8 +11,6 @@ struct CircuitStats {
 
     std::size_t num_simd_gates = 0;
     std::size_t num_nonsimd_gates = 0;
-
-    std::size_t depth = 0;
 };
 
 CircuitStats collect_stats(const encrypto::motion::BackendPointer backend);

--- a/compiler/make_results_markdown.py
+++ b/compiler/make_results_markdown.py
@@ -113,8 +113,8 @@ def build_benchmark_tables(circuits_path: str) -> str:
     for protocol in compiler.motion_backend.VALID_PROTOCOLS:
         table += f"\n### {protocol}\n"
 
-        table += "| Benchmark | Total # Gates | Depth | # SIMD gates | # Non-SIMD gates | # messages sent (party 0) | Sent size (party 0) | # messages received (party 0) | Received Size (party 0) | Runtime | Circuit Generation Time |\n"
-        table += "| - | - | - | - | - | - | - | - | - | - | - |\n"
+        table += "| Benchmark | Total # Gates | # SIMD gates | # Non-SIMD gates | # messages sent (party 0) | Sent size (party 0) | # messages received (party 0) | Received Size (party 0) | Runtime | Circuit Generation Time |\n"
+        table += "| - | - | - | - | - | - | - | - | - | - |\n"
 
         for test_case_dir in sorted(
             os.scandir(STAGES_DIR), key=lambda entry: entry.name
@@ -133,16 +133,6 @@ def build_benchmark_tables(circuits_path: str) -> str:
                     )
                     continue
 
-                if data.circuit_file:
-                    circuit_graph_path = os.path.join(
-                        circuits_path,
-                        test_case_dir.name
-                        + f"-{protocol}"
-                        + ("-Vectorized" if vectorized else "")
-                        + ".dot",
-                    )
-                    os.rename(data.circuit_file, circuit_graph_path)
-
                 table += "|"
                 table += (
                     test_case_dir.name
@@ -150,7 +140,6 @@ def build_benchmark_tables(circuits_path: str) -> str:
                     + "|"
                 )
                 table += str(data.circuit_stats.num_gates) + "|"
-                table += str(data.circuit_stats.depth) + "|"
                 table += str(data.circuit_stats.num_simd_gates) + "|"
                 table += str(data.circuit_stats.num_nonsimd_gates) + "|"
                 table += str(data.timing_stats.communication.send_num_msgs) + "|"

--- a/compiler/tests/benchmark.py
+++ b/compiler/tests/benchmark.py
@@ -14,8 +14,6 @@ class BenchmarkOutput:
     output: str
     timing_stats: statistics.TimingStatistics
     circuit_stats: statistics.CircuitStatistics
-    circuit_file: Optional[str] = None
-
 
     @classmethod
     def from_dictionary(cls, params):
@@ -23,7 +21,6 @@ class BenchmarkOutput:
         output = params["output"]
         timing_stats = params["timing_stats"]
         circuit_stats = params["circuit_stats"]
-        circuit_file = params.get("circuit_file")
 
         return cls(
             name=name,
@@ -33,21 +30,12 @@ class BenchmarkOutput:
         )
 
     def to_dictionary(self):
-        if self.circuit_file:
-            return {
-                "name": self.name,
-                "output": self.output,
-                "timing_stats": self.timing_stats,
-                "circuit_stats": self.circuit_stats,
-                "circuit_file": self.circuit_file,
-            }
-        else:
-            return {
-                "name": self.name,
-                "output": self.output,
-                "timing_stats": self.timing_stats,
-                "circuit_stats": self.circuit_stats,
-            }
+        return {
+            "name": self.name,
+            "output": self.output,
+            "timing_stats": self.timing_stats,
+            "circuit_stats": self.circuit_stats,
+        }
 
     @classmethod
     def by_accumulating_readings(cls, a, b):
@@ -187,14 +175,12 @@ def run_benchmark(
                     output=party0_output,
                     timing_stats=party0_timing_stats,
                     circuit_stats=party0_circuit_stats,
-                    circuit_file=os.path.join(party0_dir, "circuit.dot"),
                 ),
                 BenchmarkOutput(
                     name=benchmark_name,
                     output=party1_output,
                     timing_stats=party1_timing_stats,
                     circuit_stats=party1_circuit_stats,
-                    circuit_file=os.path.join(party1_dir, "circuit.dot"),
                 ),
             )
 

--- a/compiler/tests/statistics.py
+++ b/compiler/tests/statistics.py
@@ -394,7 +394,6 @@ class CircuitStatistics:
     num_simd_gates: int
     num_nonsimd_gates: int
     circuit_gen_time: float  # in milliseconds
-    depth: int
 
     @classmethod
     def from_dictionary(cls, params):
@@ -404,7 +403,6 @@ class CircuitStatistics:
         num_simd_gates = params["num_simd_gates"]
         num_nonsimd_gates = params["num_nonsimd_gates"]
         circuit_gen_time = params["circuit_gen_time"]
-        depth = params["depth"]
         return cls(
             num_gates=num_gates,
             num_inputs=num_inputs,
@@ -412,7 +410,6 @@ class CircuitStatistics:
             num_simd_gates=num_simd_gates,
             num_nonsimd_gates=num_nonsimd_gates,
             circuit_gen_time=circuit_gen_time,
-            depth=depth,
         )
 
     def to_dictionary(self):
@@ -423,7 +420,6 @@ class CircuitStatistics:
             "num_simd_gates": self.num_simd_gates,
             "num_nonsimd_gates": self.num_nonsimd_gates,
             "circuit_gen_time": self.circuit_gen_time,
-            "depth": self.depth,
         }
 
     @classmethod
@@ -458,11 +454,7 @@ def parse_circuit_data(lines: list[str]) -> CircuitStatistics:
     assert nonsimd_gates_data[0] == "num_nonsimd_gates:"
     num_nonsimd_gates = int(nonsimd_gates_data[1])
 
-    depth_data = lines[5].split()
-    assert depth_data[0] == "depth:"
-    depth = int(depth_data[1])
-
-    circuit_gen_time_data = lines[6].split()
+    circuit_gen_time_data = lines[5].split()
     assert circuit_gen_time_data[0] == "circuit_gen_time:"
     circuit_gen_time = float(circuit_gen_time_data[1])
 
@@ -473,5 +465,4 @@ def parse_circuit_data(lines: list[str]) -> CircuitStatistics:
         num_simd_gates=num_simd_gates,
         num_nonsimd_gates=num_nonsimd_gates,
         circuit_gen_time=circuit_gen_time,
-        depth=depth,
     )


### PR DESCRIPTION
The latest MOTION removed `GetWaitingGatesIds()`, which was used to compute circuit depth and create a Graphviz diagram. I couldn't find another way to walk the circuit as a graph, so this functionality is removed for now.